### PR TITLE
feat: improve SMTP test with validation, add ElasticEmail test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,16 @@ python3 feature-engine/smtp_test.py
 ```
 
 A ✅ message indicates that the email was accepted by the SMTP server.
+
+## Tester l'envoi d'email avec ElasticEmail
+
+Pour tester rapidement l'envoi des alertes par email avec le service
+ElasticEmail, utilisez le script `smtp_run_test.sh` à la racine du dépôt :
+
+```bash
+./smtp_run_test.sh
+```
+
+Le script exporte automatiquement les variables d'environnement nécessaires puis
+exécute `smtp_test.py`. Si tout est correct, le message `✅ Email sent` doit
+s'afficher.

--- a/feature-engine/smtp_test.py
+++ b/feature-engine/smtp_test.py
@@ -11,16 +11,20 @@ SMTP_PASSWORD = os.getenv("SMTP_PASSWORD")
 ALERT_EMAIL_FROM = os.getenv("ALERT_EMAIL_FROM")
 ALERT_EMAIL_TO = os.getenv("ALERT_EMAIL_TO")
 
-missing = []
-if not ALERT_EMAIL_FROM:
-    missing.append("ALERT_EMAIL_FROM")
-if not ALERT_EMAIL_TO:
-    missing.append("ALERT_EMAIL_TO")
-if not SMTP_SERVER:
-    missing.append("SMTP_SERVER")
+required = {
+    "SMTP_SERVER": SMTP_SERVER,
+    "SMTP_USERNAME": SMTP_USERNAME,
+    "ALERT_EMAIL_FROM": ALERT_EMAIL_FROM,
+    "ALERT_EMAIL_TO": ALERT_EMAIL_TO,
+}
 
+missing = [name for name, val in required.items() if not val]
 if missing:
-    print(f"❌ Missing required SMTP configuration: {', '.join(missing)}")
+    print(
+        "❌ Erreur : Les variables "
+        + ", ".join(missing)
+        + " doivent être définies."
+    )
     sys.exit(1)
 
 msg = MIMEMultipart()

--- a/smtp_run_test.sh
+++ b/smtp_run_test.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Helper script to test SMTP alerts with ElasticEmail
+
+export SMTP_SERVER="smtp.elasticemail.com"
+export SMTP_PORT="2525"
+export SMTP_USERNAME="autreuser5@gmail.com"
+export SMTP_PASSWORD="1C1587C036DDF3B6AEA54CA1E31994DB012F"
+export ALERT_EMAIL_FROM="autreuser5@gmail.com"
+export ALERT_EMAIL_TO="ruben.nyaku2@gmail.com"
+
+echo "[INFO] Running smtp_test.py with ElasticEmail credentials..."
+python3 feature-engine/smtp_test.py
+


### PR DESCRIPTION
## Summary
- validate SMTP variables before sending test email
- provide helper script to run the test with ElasticEmail credentials
- document how to run the email test

## Testing
- `./smtp_run_test.sh` *(fails: Network is unreachable)*
- `python3 feature-engine/smtp_test.py` with unset vars

------
https://chatgpt.com/codex/tasks/task_e_68814be1a7d4832cb1342922bf060728