### PR TITLE
feat: switch smtp_run_test.sh to use Mailtrap for unrestricted email testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,5 +30,17 @@ ElasticEmail, utilisez le script `smtp_run_test.sh` à la racine du dépôt :
 ```
 
 Le script exporte automatiquement les variables d'environnement nécessaires puis
-exécute `smtp_test.py`. Si tout est correct, le message `✅ Email sent` doit
+exécute `smtp_test.py`. Si tout est correct, le message `✅ Email envoyé avec succès` doit
 s'afficher.
+
+## Tester avec Mailtrap
+
+Si vous souhaitez lever les limitations du service ElasticEmail gratuit,
+vous pouvez utiliser l'environnement de test [Mailtrap](https://mailtrap.io).
+Il suffit d'exécuter :
+
+```bash
+./smtp_run_test.sh
+```
+
+Les emails générés apparaîtront directement dans la sandbox Mailtrap.

--- a/feature-engine/smtp_test.py
+++ b/feature-engine/smtp_test.py
@@ -39,6 +39,6 @@ try:
         if SMTP_USERNAME and SMTP_PASSWORD:
             server.login(SMTP_USERNAME, SMTP_PASSWORD)
         server.sendmail(ALERT_EMAIL_FROM, [ALERT_EMAIL_TO], msg.as_string())
-    print("✅ Email sent")
+    print("✅ Email envoyé avec succès")
 except Exception as e:
-    print(f"❌ Failed to send email: {e}")
+    print(f"❌ Erreur lors de l'envoi de l'email: {e}")

--- a/smtp_run_test.sh
+++ b/smtp_run_test.sh
@@ -1,13 +1,16 @@
 #!/bin/bash
-# Helper script to test SMTP alerts with ElasticEmail
+# Helper script to test SMTP alerts.
+# This version uses a Mailtrap sandbox account so that
+# emails can be sent without the restrictions of the
+# free ElasticEmail tier.
 
-export SMTP_SERVER="smtp.elasticemail.com"
-export SMTP_PORT="2525"
-export SMTP_USERNAME="autreuser5@gmail.com"
-export SMTP_PASSWORD="1C1587C036DDF3B6AEA54CA1E31994DB012F"
-export ALERT_EMAIL_FROM="autreuser5@gmail.com"
-export ALERT_EMAIL_TO="ruben.nyaku2@gmail.com"
+export SMTP_SERVER="sandbox.smtp.mailtrap.io"
+export SMTP_PORT="587"
+export SMTP_USERNAME="5eb439d4e17458"
+export SMTP_PASSWORD="02740c73cbcd88"
+export ALERT_EMAIL_FROM="test@mailtrap.io"
+export ALERT_EMAIL_TO="any@recipient.com"
 
-echo "[INFO] Running smtp_test.py with ElasticEmail credentials..."
+echo "[INFO] Running smtp_test.py with Mailtrap credentials..."
 python3 feature-engine/smtp_test.py
 


### PR DESCRIPTION
## Summary
- use Mailtrap credentials inside `smtp_run_test.sh`
- clarify success/failure messages in `smtp_test.py`
- document Mailtrap usage for email testing in README

## Testing
- `bash -n smtp_run_test.sh`
- `python3 -m py_compile feature-engine/smtp_test.py`
- `./smtp_run_test.sh` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68815ecd82f8832c88ee004be0421aa5