### PR TITLE
feat: add email alert alongside Slack in notify_alert

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Memoire PLUTON
 
 This repository contains experimentation scripts for SIP attack detection.
+When an attack is detected, the feature engine now sends both a Slack message
+and an email notification.
 
 ## SMTP configuration
 
@@ -9,6 +11,10 @@ Email alerts require a working SMTP account. Set the following environment varia
 - `SMTP_SERVER` and `SMTP_PORT`
 - `SMTP_USERNAME` and `SMTP_PASSWORD`
 - `ALERT_EMAIL_FROM` and `ALERT_EMAIL_TO`
+- `ENABLE_EMAIL_ALERT` (set to `false` to disable email alerts)
+
+`ENABLE_EMAIL_ALERT` defaults to `true` so emails are sent unless explicitly
+disabled.
 
 For local testing you can use services like [ElasticEmail](https://elasticemail.com) or [Mailtrap](https://mailtrap.io). Ensure these variables are exported or present in your `.env` file.
 
@@ -35,9 +41,8 @@ s'afficher.
 
 ## Tester avec Mailtrap
 
-Si vous souhaitez lever les limitations du service ElasticEmail gratuit,
-vous pouvez utiliser l'environnement de test [Mailtrap](https://mailtrap.io).
-Il suffit d'exécuter :
+Les tests utilisent la sandbox [Mailtrap](https://mailtrap.io) pour recevoir les
+emails sans les envoyer vers de vraies adresses. Il suffit d'exécuter :
 
 ```bash
 ./smtp_run_test.sh


### PR DESCRIPTION
## Summary
- support optional email notifications via `ENABLE_EMAIL_ALERT`
- send Slack alert with new helper and send email when enabled
- clarify double notification and Mailtrap usage in README

## Testing
- `python3 -m py_compile feature-engine/feature_engine.py`
- `python3 -m py_compile feature-engine/*.py`

------
https://chatgpt.com/codex/tasks/task_e_688160d17fcc832c8364c7270e601a35