### PR TITLE
Fix feature engine main loop

### DIFF
--- a/feature-engine/feature_engine.py
+++ b/feature-engine/feature_engine.py
@@ -163,7 +163,14 @@ def flush_timeout_sessions(now_ts):
 
 def main():
     """Lecture du flux JSON EK sur stdin et traitement session par session."""
-    for line in sys.stdin:
+    print("\u2705 feature-engine is now monitoring SIP traffic…")
+    stdin = sys.stdin
+    while True:
+        line = stdin.readline()
+        if not line:
+            flush_timeout_sessions(time.time())
+            time.sleep(0.5)
+            continue
         try:
             obj = json.loads(line)
         except json.JSONDecodeError:


### PR DESCRIPTION
## Summary
- keep `feature_engine.py` alive by looping with readline
- log when monitoring starts

## Testing
- `python3 -m py_compile feature-engine/feature_engine.py`
- `python3 feature-engine/feature_engine.py < feature-engine/sample.jsonl &` (manual stop)

------
https://chatgpt.com/codex/tasks/task_e_6881634eaa40832cb288b9bb151c1d76