### PR TITLE
Fix Slack token handling

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,9 +25,11 @@ services:
       - pluton-api
     networks:
       - sipp-net
+    env_file:
+      - .env
     environment:
-      SLACK_TOKEN: "xoxb-XXXXXXXXXXXX"
-      SLACK_CHANNEL: "#sip-alerts"
+      SLACK_TOKEN: ${SLACK_TOKEN}
+      SLACK_CHANNEL: ${SLACK_CHANNEL}
 
   packet-capture:
     image: nicolaka/netshoot

--- a/feature-engine/feature_engine.py
+++ b/feature-engine/feature_engine.py
@@ -17,6 +17,10 @@ API_URL = os.getenv("PREDICT_URL", default_url)
 SLACK_TOKEN = os.getenv("SLACK_TOKEN")
 SLACK_CHANNEL = os.getenv("SLACK_CHANNEL")
 
+logging.info(
+    "Using SLACK_TOKEN %s and channel %s", (SLACK_TOKEN or "")[:10] + "...", SLACK_CHANNEL
+)
+
 # Enable/disable email alerts ("false" to deactivate)
 ENABLE_EMAIL_ALERT = os.getenv("ENABLE_EMAIL_ALERT", "true").lower()
 
@@ -239,4 +243,8 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    if "--test-slack" in sys.argv:
+        print(f"SLACK_TOKEN={SLACK_TOKEN[:10]}... CHANNEL={SLACK_CHANNEL}")
+        send_slack_alert("✅ Slack token test OK")
+    else:
+        main()


### PR DESCRIPTION
## Summary
- load Slack env variables from `.env` in docker-compose
- log Slack token prefix and channel during feature-engine start
- add `--test-slack` helper to feature_engine for easier debugging

## Testing
- `python3 -m py_compile feature-engine/feature_engine.py`

------
https://chatgpt.com/codex/tasks/task_e_68816bfa1038832c9291f0aca438e361