### PR TITLE
Fix sip-server build path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,9 @@ services:
 
   sip-server:
     image: my-sipp-client
+    build:
+      context: .
+      dockerfile: Dockerfile
     container_name: sip-server
     networks:
       - sipp-net


### PR DESCRIPTION
## Summary
- add build config for `sip-server` so docker-compose builds the image instead of pulling

## Testing
- `docker-compose config`

------
https://chatgpt.com/codex/tasks/task_e_688218c72e3c832c91ef3db5522d2760