### PR TITLE
Fix SIP parsing for INVITE and REGISTER flood detection

### DIFF
--- a/feature-engine/feature_engine.py
+++ b/feature-engine/feature_engine.py
@@ -223,10 +223,14 @@ def main():
         ipsec = layers.get("ip", {})
 
         call_id = sip.get("sip_sip_Call-ID") or sip.get("sip_sip_call_id_generated")
+        if call_id:
+            call_id = str(call_id).strip()
         if not call_id:
             continue
 
         method = sip.get("sip_sip_CSeq_method") or sip.get("sip_sip_Method", "")
+        method = str(method).strip().upper()
+        logging.debug("Parsed SIP method %s for %s", method, call_id)
         ts     = float(
             frame.get("frame_frame_time_relative", frame.get("frame_frame_time_delta", 0))
         )


### PR DESCRIPTION
## Summary
- normalize SIP Call-ID and Method fields when reading JSON
- log each parsed SIP method for easier debugging

## Testing
- `python3 feature-engine/feature_engine.py < feature-engine/sample.jsonl` *(fails: 403 Client Error due to blocked network)*

------
https://chatgpt.com/codex/tasks/task_e_688290df3a04832c8e20dc8fe213bddf